### PR TITLE
Easier pinning of `roc` and `roc_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,22 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/niclas-ahden/joy"
 version = "0.0.1"
+
+[workspace.dependencies]
+# NOTE: You can pin the version/commit of Roc by specifying a rev (commit) like so:
+#
+#     roc_std = {
+#       git = "https://github.com/roc-lang/roc.git",
+#       rev = "9fcd5a3fe88a1911ccd56ecf6e5df88c4f16c098",
+#     }
+#
+# Likewise you can pin to a branch or tag like so:
+#
+#       branch = "foo",
+#    or
+#       tag = "v0.1.0",
+#
+# See: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
+#
+# Remember to also pin the Roc compiler to the same version in `./flake.nix` (or however else you install the compiler).
+roc_std = { git = "https://github.com/roc-lang/roc.git" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,4 +9,4 @@ description.workspace = true
 
 [dependencies]
 roc = { path = "../roc" }
-roc_std = { git = "https://github.com/roc-lang/roc.git" }
+roc_std = { workspace = true}

--- a/crates/roc/Cargo.toml
+++ b/crates/roc/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 description.workspace = true
 
 [dependencies]
-roc_std = { git = "https://github.com/roc-lang/roc.git" }
+roc_std = { workspace = true}
 wee_alloc = "0.4.5"
 
 [build-dependencies]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -15,10 +15,13 @@ console_error_panic_hook = "0.1.7"
 percy-dom = { version = "0.10.0", default-features = false }
 reqwest = { version = "0.12.9" }
 roc = { path = "../roc" }
-roc_std = { git = "https://github.com/roc-lang/roc.git" }
+roc_std = { workspace = true}
 wasm-bindgen = "0.2.95"
 wasm-bindgen-futures = "0.4.45"
 wee_alloc = "0.4.5"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
 
 [dependencies.web-sys]
 version = "0.3.72"

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,12 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    # NOTE: You can pin the version/commit of Roc by appending /<commit> to the URL like so:
+    #
+    #     roc.url = "github:roc-lang/roc/9fcd5a3fe88a1911ccd56ecf6e5df88c4f16c098";
+    #
+    # Remember to also pin `roc_std` to the same commit in `./Cargo.toml`.
     roc.url = "github:roc-lang/roc";
-    # roc.url = "github:roc-lang/roc/50ec8ef1d1aa9abb2fda6948fb13abb431940ddf";
   };
 
   outputs = { nixpkgs, flake-utils, roc, ... }:


### PR DESCRIPTION
Make pinning easier and discoverable for those unfamiliar with Nix and/or cargo.